### PR TITLE
Support user defined result code

### DIFF
--- a/onactivityresult-compiler/src/main/java/onactivityresult/compiler/OnActivityResultProcessor.java
+++ b/onactivityresult-compiler/src/main/java/onactivityresult/compiler/OnActivityResultProcessor.java
@@ -56,6 +56,10 @@ public class OnActivityResultProcessor extends AbstractProcessor {
 
     private static final String FQN_ANDROID_INTENT = "android.content.Intent";
 
+    private static final int RESULT_CANCELED = 0;
+    private static final int RESULT_OK = -1;
+    private static final int RESULT_FIRST_USER = 1;
+
     private Filer filer;
     private Elements elementUtils;
     private Types typeUtils;
@@ -287,6 +291,10 @@ public class OnActivityResultProcessor extends AbstractProcessor {
         final Set<Integer> set = new HashSet<>(filterResultCodes.length);
 
         for (final int filterResultCode : filterResultCodes) {
+            if (filterResultCode != RESULT_CANCELED && filterResultCode != RESULT_OK && filterResultCode < RESULT_FIRST_USER) {
+                throw new OnActivityResultProcessingException(element, "Invalid resultCode %s", filterResultCode);
+            }
+
             if (set.contains(filterResultCode)) {
                 throw new OnActivityResultProcessingException(element, "Duplicate resultCode %s", filterResultCode);
             } else {

--- a/onactivityresult-compiler/src/main/java/onactivityresult/compiler/OnActivityResultProcessor.java
+++ b/onactivityresult-compiler/src/main/java/onactivityresult/compiler/OnActivityResultProcessor.java
@@ -56,9 +56,7 @@ public class OnActivityResultProcessor extends AbstractProcessor {
 
     private static final String FQN_ANDROID_INTENT = "android.content.Intent";
 
-    private static final int RESULT_CANCELED = 0;
     private static final int RESULT_OK = -1;
-    private static final int RESULT_FIRST_USER = 1;
 
     private Filer filer;
     private Elements elementUtils;
@@ -291,7 +289,7 @@ public class OnActivityResultProcessor extends AbstractProcessor {
         final Set<Integer> set = new HashSet<>(filterResultCodes.length);
 
         for (final int filterResultCode : filterResultCodes) {
-            if (filterResultCode != RESULT_CANCELED && filterResultCode != RESULT_OK && filterResultCode < RESULT_FIRST_USER) {
+            if (filterResultCode < RESULT_OK) {
                 throw new OnActivityResultProcessingException(element, "Invalid resultCode %s", filterResultCode);
             }
 

--- a/onactivityresult-compiler/src/main/java/onactivityresult/compiler/OnActivityResultProcessor.java
+++ b/onactivityresult-compiler/src/main/java/onactivityresult/compiler/OnActivityResultProcessor.java
@@ -56,10 +56,6 @@ public class OnActivityResultProcessor extends AbstractProcessor {
 
     private static final String FQN_ANDROID_INTENT = "android.content.Intent";
 
-    private static final int RESULT_CANCELED = 0;
-    private static final int RESULT_OK = -1;
-    private static final int RESULT_FIRST_USER = 1;
-
     private Filer filer;
     private Elements elementUtils;
     private Types typeUtils;
@@ -291,10 +287,6 @@ public class OnActivityResultProcessor extends AbstractProcessor {
         final Set<Integer> set = new HashSet<>(filterResultCodes.length);
 
         for (final int filterResultCode : filterResultCodes) {
-            if (filterResultCode != RESULT_CANCELED && filterResultCode != RESULT_FIRST_USER && filterResultCode != RESULT_OK) {
-                throw new OnActivityResultProcessingException(element, "Invalid resultCode %s", filterResultCode);
-            }
-
             if (set.contains(filterResultCode)) {
                 throw new OnActivityResultProcessingException(element, "Duplicate resultCode %s", filterResultCode);
             } else {

--- a/onactivityresult-compiler/src/test/java/onactivityresult/OnActivityResultResultCodesValidationTest.java
+++ b/onactivityresult-compiler/src/test/java/onactivityresult/OnActivityResultResultCodesValidationTest.java
@@ -13,15 +13,6 @@ public class OnActivityResultResultCodesValidationTest {
     }
 
     @Test
-    public void positiveInvalidFilterResultCodes() {
-        //@formatter:off
-        TestActivity.create().build(
-            "@OnActivityResult(requestCode = 1, resultCodes = {2}) void myOnActivityResult() { }"
-        ).failsWithErrorMessage("Invalid resultCode 2. (test.TestActivity.myOnActivityResult)", 1);
-        //@formatter:on
-    }
-
-    @Test
     public void activityResultDuplicatedFilterResultCodesShouldLetProcessorNotFail() {
         //@formatter:off
         TestActivity.create().hasActivity().build(
@@ -53,6 +44,15 @@ public class OnActivityResultResultCodesValidationTest {
         //@formatter:off
         TestActivity.create().hasActivity().build(
             "@OnActivityResult(requestCode = 1, resultCodes = { Activity.RESULT_FIRST_USER }) void myOnActivityResult() { }"
+        ).succeeds();
+        //@formatter:on
+    }
+
+    @Test
+    public void activityResultUserDefinedFilterResultCodesShouldLetProcessorNotFail() {
+        //@formatter:off
+        TestActivity.create().hasActivity().build(
+                "@OnActivityResult(requestCode = 1, resultCodes = { Activity.RESULT_FIRST_USER + 1 }) void myOnActivityResult() { }"
         ).succeeds();
         //@formatter:on
     }

--- a/onactivityresult-sample/src/main/java/com/vanniktech/onactivityresult/sample/ForResultActivity.java
+++ b/onactivityresult-sample/src/main/java/com/vanniktech/onactivityresult/sample/ForResultActivity.java
@@ -10,6 +10,9 @@ import butterknife.ButterKnife;
 import butterknife.OnClick;
 
 public class ForResultActivity extends AppCompatActivity {
+
+    public static final int RESULT_USER_DEFINED = Activity.RESULT_FIRST_USER + 1;
+
     @BindView(R.id.toolbar) Toolbar toolbar;
 
     @Override
@@ -31,6 +34,12 @@ public class ForResultActivity extends AppCompatActivity {
     @OnClick(R.id.close_with_resultcode_cancel)
     void onResultCodeCanceledClicked() {
         this.setResult(Activity.RESULT_CANCELED);
+        this.finish();
+    }
+
+    @OnClick(R.id.close_with_resultcode_user_defined)
+    void onResultCodeUserDefinedClicked() {
+        this.setResult(RESULT_USER_DEFINED);
         this.finish();
     }
 }

--- a/onactivityresult-sample/src/main/java/com/vanniktech/onactivityresult/sample/ForResultActivity.java
+++ b/onactivityresult-sample/src/main/java/com/vanniktech/onactivityresult/sample/ForResultActivity.java
@@ -11,7 +11,7 @@ import butterknife.OnClick;
 
 public class ForResultActivity extends AppCompatActivity {
 
-    public static final int RESULT_USER_DEFINED = Activity.RESULT_FIRST_USER + 1;
+    static final int RESULT_USER_DEFINED = Activity.RESULT_FIRST_USER + 1;
 
     @BindView(R.id.toolbar) Toolbar toolbar;
 

--- a/onactivityresult-sample/src/main/java/com/vanniktech/onactivityresult/sample/MainActivity.java
+++ b/onactivityresult-sample/src/main/java/com/vanniktech/onactivityresult/sample/MainActivity.java
@@ -70,6 +70,11 @@ public class MainActivity extends AppCompatActivity {
         Toast.makeText(this, "Got activity for result canceled", Toast.LENGTH_SHORT).show();
     }
 
+    @OnActivityResult(requestCode = REQUEST_CODE_TEST_ACTIVITY, resultCodes = {ForResultActivity.RESULT_USER_DEFINED})
+    void onActivityResultTestActivityUserDefined(final int resultCode) {
+        Toast.makeText(this, "Got activity for result user defined. resultCode = " + resultCode, Toast.LENGTH_SHORT).show();
+    }
+
     @OnActivityResult(requestCode = REQUEST_CODE_TEST_2_ACTIVITY)
     void onActivityResultTest2Activity(final int resultCode, final Intent intent) {
         Toast.makeText(this, "Got activity for result 2 " + resultCode + " with intent " + intent, Toast.LENGTH_SHORT).show();

--- a/onactivityresult-sample/src/main/res/layout/content_for_result.xml
+++ b/onactivityresult-sample/src/main/res/layout/content_for_result.xml
@@ -27,4 +27,11 @@
         android:layout_height="wrap_content"
         android:text="Close with ResultCode Cancel"
         tools:ignore="HardcodedText"/>
+
+    <Button
+        android:id="@+id/close_with_resultcode_user_defined"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Close with ResultCode user defined"
+        tools:ignore="HardcodedText"/>
 </LinearLayout>


### PR DESCRIPTION
Support user defined result code.

There is `Activity.RESULT_FIRST_USER` which can create user defined result code.
https://developer.android.com/reference/android/app/Activity.html#RESULT_FIRST_USER

I want to use it and return a result code.

If you agree with this proposal, I will fix the test code.

## Example

I wrote the sample to make the contents of the proposal easy to understand.

```java
public class ForResultActivity extends AppCompatActivity {
    public static final int RESULT_USER_DEFINED = Activity.RESULT_FIRST_USER + 1;

    @OnClick(R.id.close_with_resultcode_user_defined)
    void onResultCodeUserDefinedClicked() {
        this.setResult(RESULT_USER_DEFINED);
        this.finish();
    }
}

public class MainActivity extends AppCompatActivity {

    @OnActivityResult(requestCode = REQUEST_CODE_TEST_ACTIVITY, 
            resultCodes = {ForResultActivity.RESULT_USER_DEFINED})
    void onActivityResultTestActivityUserDefined(final int resultCode) {
        Toast.makeText(this, "Got activity for result user defined. resultCode = " + resultCode, Toast.LENGTH_SHORT).show();
    }
}
```
